### PR TITLE
Remove "sunglasses" duplicate

### DIFF
--- a/src/Emojis/emoji.php
+++ b/src/Emojis/emoji.php
@@ -91,5 +91,4 @@ return [
     "white_check_mark"          => "\u{2705}",
     "question"                  => "\u{2753}",
     "tada"                      => "\u{1F389}",
-    "sunglasses"                => "\u{1F60E}",
 ];


### PR DESCRIPTION
I apologize for my mistake of adding a second "sunglasses" line. I searched (inside the edit file window) and did not find any results, but now I see it's on the list and the second one should be removed to keep things neat.